### PR TITLE
Feature/firewalls

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
     - [Resources](#resources)
         - [`triton_key`](#tritonkey)
         - [`triton_machine`](#tritonmachine)
+        - [`triton_firewall_rule`](#tritonfirewallrule)
 
 <!-- markdown-toc end -->
 
@@ -85,6 +86,18 @@ resource "triton_machine" "testmachine" {
     test = "hello!"
   }
   networks = ["42325ea0-eb62-44c1-8eb6-0af3e2f83abc"]
+}
+```
+
+### `triton_firewall_rule`
+
+Creates and manages firewall rules in Triton. Note that the API currently
+defaults rules to being disabled, so this provider does too.
+
+```hcl
+resource "triton_firewall_rule" "testrule" {
+    rule = "FROM any TO tag www ALLOW tcp PORT 80"
+    enabled = true
 }
 ```
 

--- a/provider.go
+++ b/provider.go
@@ -40,8 +40,9 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"triton_key":     resourceKey(),
-			"triton_machine": resourceMachine(),
+			"triton_key":           resourceKey(),
+			"triton_machine":       resourceMachine(),
+			"triton_firewall_rule": resourceFirewallRule(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/resource_firewall_rule.go
+++ b/resource_firewall_rule.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/joyent/gosdc/cloudapi"
+)
+
+func resourceFirewallRule() *schema.Resource {
+	return &schema.Resource{
+		Create: wrapCallback(resourceFirewallRuleCreate),
+		Exists: wrapExistsCallback(resourceFirewallRuleExists),
+		Read:   wrapCallback(resourceFirewallRuleRead),
+		Update: wrapCallback(resourceFirewallRuleUpdate),
+		Delete: wrapCallback(resourceFirewallRuleDelete),
+
+		Schema: map[string]*schema.Schema{
+			// required
+			"rule": {
+				Description: "firewall rule text",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+
+			// optional
+			"enabled": {
+				Description: "Indicates if the rule is enabled",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				// TODO: this feels like it should be true by default, but the API docs
+				// say that the API has it false by default. Do we want to change this
+				// default for this resource?
+			},
+		},
+	}
+}
+
+func resourceFirewallRuleCreate(d ResourceData, config *Config) error {
+	cloud, err := config.Cloud()
+	if err != nil {
+		return err
+	}
+
+	rule, err := cloud.CreateFirewallRule(cloudapi.CreateFwRuleOpts{
+		Rule:    d.Get("rule").(string),
+		Enabled: d.Get("enabled").(bool),
+	})
+	if err != nil {
+		return err
+	}
+
+	d.SetId(rule.Id)
+
+	err = resourceFirewallRuleRead(d, config)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceFirewallRuleExists(d ResourceData, config *Config) (bool, error) {
+	api, err := config.Cloud()
+	if err != nil {
+		return false, err
+	}
+
+	rule, err := api.GetFirewallRule(d.Id())
+
+	return rule != nil && err == nil, err
+}
+
+func resourceFirewallRuleRead(d ResourceData, config *Config) error {
+	cloud, err := config.Cloud()
+	if err != nil {
+		return err
+	}
+
+	rule, err := cloud.GetFirewallRule(d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.SetId(rule.Id)
+	d.Set("rule", rule.Rule)
+	d.Set("enabled", rule.Enabled)
+
+	return nil
+}
+
+func resourceFirewallRuleUpdate(d ResourceData, config *Config) error {
+	cloud, err := config.Cloud()
+	if err != nil {
+		return err
+	}
+
+	_, err = cloud.UpdateFirewallRule(
+		d.Id(),
+		cloudapi.CreateFwRuleOpts{
+			Rule:    d.Get("rule").(string),
+			Enabled: d.Get("enabled").(bool),
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	return resourceFirewallRuleRead(d, config)
+}
+
+func resourceFirewallRuleDelete(d ResourceData, config *Config) error {
+	cloud, err := config.Cloud()
+	if err != nil {
+		return err
+	}
+
+	err = cloud.DeleteFirewallRule(d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+
+	return nil
+}

--- a/resource_firewall_rule_test.go
+++ b/resource_firewall_rule_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"github.com/joyent/gosdc/cloudapi"
+	"github.com/joyent/triton-terraform/helpers"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type ResourceFirewallRuleSuite struct {
+	suite.Suite
+
+	server    *helpers.Server
+	config    *Config
+	api       *cloudapi.Client
+	initialID string
+	mock      *MockResourceData
+}
+
+func (s *ResourceFirewallRuleSuite) SetupTest() {
+	var err error
+	s.server, err = helpers.NewServer()
+	s.Require().Nil(err)
+
+	s.config = &Config{
+		Account: helpers.TestAccount,
+		Key:     helpers.TestKeyFile,
+		KeyID:   helpers.TestKeyID,
+		URL:     s.server.URL(),
+	}
+
+	s.api, err = s.config.Cloud()
+	s.Require().Nil(err)
+
+	s.initialID = "aaaaaaaa-bbbb-cccc-dddddddddddd"
+	s.mock = NewMockResourceData(
+		s.initialID,
+		map[string]interface{}{
+			"rule":    "FROM any TO tag www ALLOW tcp PORT 80",
+			"enabled": true,
+		},
+	)
+}
+
+func (s *ResourceFirewallRuleSuite) TeardownTest() {
+	s.server.Stop()
+}
+
+func (s *ResourceFirewallRuleSuite) CreateFirewallRule() *cloudapi.FirewallRule {
+	rule, err := s.api.CreateFirewallRule(cloudapi.CreateFwRuleOpts{
+		Rule:    s.mock.Get("rule").(string),
+		Enabled: s.mock.Get("enabled").(bool),
+	})
+	s.Require().Nil(err)
+
+	return rule
+}
+
+func (s *ResourceFirewallRuleSuite) TestCreateValid() {
+	err := resourceFirewallRuleCreate(s.mock, s.config)
+	s.Assert().Nil(err)
+
+	// assert that the new ID is now set
+	s.Assert().NotEqual(s.mock.ID, s.initialID)
+
+	// get the resource back and check the fields
+	rule, err := s.api.GetFirewallRule(s.mock.ID)
+	s.Require().Nil(err)
+	s.Require().NotNil(rule)
+
+	s.Assert().Equal(rule.Enabled, s.mock.Get("enabled"))
+	s.Assert().Equal(rule.Rule, s.mock.Get("rule"))
+}
+
+func (s *ResourceFirewallRuleSuite) TestRead() {
+	rule := s.CreateFirewallRule()
+
+	s.mock.SetId(rule.Id)
+	s.mock.Set("rule", "")
+	s.mock.Set("enabled", false)
+
+	err := resourceFirewallRuleRead(s.mock, s.config)
+	s.Assert().Nil(err)
+
+	s.Assert().Equal(s.mock.Get("rule"), rule.Rule)
+	s.Assert().Equal(s.mock.Get("enabled"), rule.Enabled)
+}
+
+func (s *ResourceFirewallRuleSuite) TestUpdate() {
+	rule := s.CreateFirewallRule()
+
+	s.mock.SetId(rule.Id)
+	newRule := "FROM any TO tag www BLOCK tcp PORT 80"
+	s.mock.Change("rule", newRule)
+	s.mock.Change("enabled", false)
+
+	err := resourceFirewallRuleUpdate(s.mock, s.config)
+	s.Assert().Nil(err)
+
+	rule, err = s.api.GetFirewallRule(rule.Id)
+	s.Assert().Nil(err)
+	s.Assert().Equal(rule.Rule, newRule)
+	s.Assert().False(rule.Enabled)
+}
+
+func (s *ResourceFirewallRuleSuite) TestDelete() {
+	rule := s.CreateFirewallRule()
+	s.mock.SetId(rule.Id)
+
+	err := resourceFirewallRuleDelete(s.mock, s.config)
+	s.Assert().Nil(err)
+
+	rule, err = s.api.GetFirewallRule(rule.Id)
+	s.Assert().Nil(rule)
+	s.Assert().NotNil(err)
+}
+
+func TestResourceFirewallRuleSuite(t *testing.T) {
+	suite.Run(t, new(ResourceFirewallRuleSuite))
+}

--- a/resource_machine_test.go
+++ b/resource_machine_test.go
@@ -36,10 +36,11 @@ func (s *ResourceMachineSuite) SetupTest() {
 	s.mock = NewMockResourceData(
 		s.initialID,
 		map[string]interface{}{
-			"name":     "test",
-			"package":  "12345678-aaaa-bbbb-cccc-000000000000",            // Micro
-			"image":    "12345678-a1a1-b2b2-c3c3-098765432100",            // SmartOS Std
-			"networks": []interface{}{"123abc4d-0011-aabb-2233-ccdd4455"}, // Test-Joyent-Public
+			"name":             "test",
+			"package":          "12345678-aaaa-bbbb-cccc-000000000000",            // Micro
+			"image":            "12345678-a1a1-b2b2-c3c3-098765432100",            // SmartOS Std
+			"networks":         []interface{}{"123abc4d-0011-aabb-2233-ccdd4455"}, // Test-Joyent-Public
+			"firewall_enabled": false,
 			"tags": map[string]interface{}{
 				"hello": "world",
 			},
@@ -82,6 +83,8 @@ func (s *ResourceMachineSuite) TestCreateValid() {
 	s.Assert().NotNil(machine.Networks)
 	s.Assert().Equal(machine.Networks, s.mock.Get("networks"))
 
+	s.Assert().False(s.mock.Get("firewall_enabled").(bool))
+
 	s.Assert().NotNil(machine.Tags)
 	s.Assert().Equal(machine.Tags, s.mock.Get("tags"))
 	s.Assert().NotNil(machine.Metadata)
@@ -101,6 +104,7 @@ func (s *ResourceMachineSuite) TestRead() {
 	s.mock.Set("name", "")
 	s.mock.Set("package", "")
 	s.mock.Set("image", "")
+	// TODO: s.mock.Set("firewall_enabled", "")
 
 	err := resourceMachineRead(s.mock, s.config)
 	s.Assert().Nil(err)
@@ -108,6 +112,7 @@ func (s *ResourceMachineSuite) TestRead() {
 	s.Assert().Equal(s.mock.Get("name"), machine.Name)
 	s.Assert().Equal(s.mock.Get("package"), machine.Package)
 	s.Assert().Equal(s.mock.Get("image"), machine.Image)
+	// TODO: s.Assert().False(s.mock.Get("firewall_enabled").(bool))
 }
 
 func (s *ResourceMachineSuite) TestUpdateName() {
@@ -197,6 +202,19 @@ func (s *ResourceMachineSuite) TestUpdateMetadatas() {
 		s.Assert().Nil(err)
 		s.Assert().NotEqual(machine.Metadata[apiKey], newValue)
 	}
+}
+
+func (s *ResourceMachineSuite) TestUpdateFirewall() {
+	machine := s.CreateMachine()
+	s.mock.SetId(machine.Id)
+
+	s.mock.Change("firewall_enabled", true)
+
+	err := resourceMachineUpdate(s.mock, s.config)
+	s.Assert().Nil(err)
+
+	// TODO: get machine to verify once FirewallEnabled is on the Machine struct
+	s.Assert().True(s.mock.Get("firewall_enabled").(bool))
 }
 
 func (s *ResourceMachineSuite) TestDelete() {


### PR DESCRIPTION
Adds firewalls. Also adds the `firewall_enabled` flag on machines, but see the note on 05e3802 and https://github.com/joyent/gosdc/issues/9

The resource I've been using for testing is included in the README, but also as follows:

```hcl
resource "triton_firewall_rule" "testrule" {
  rule = "FROM any TO tag www ALLOW tcp PORT 80"
  enabled = true
}
```