### PR TITLE
add example from blog post

### DIFF
--- a/examples/triton-docker-combined/.gitignore
+++ b/examples/triton-docker-combined/.gitignore
@@ -1,0 +1,2 @@
+terraform.tfvars
+*.tfstate

--- a/examples/triton-docker-combined/terraform.tfvars.example
+++ b/examples/triton-docker-combined/terraform.tfvars.example
@@ -1,0 +1,7 @@
+account = "bobby.brown"
+triton_url = "https://us-sw-1.api.joyentcloud.com"
+key_path = "~/.ssh/joyent_id_rsa"
+key_id = "<KEY_FINGERPRINT>"
+
+cert_path = "/Users/<USER>/.sdc/docker/<SDC_ACCOUNT>"
+docker_host = "tcp://us-sw-1.docker.joyent.com:2376"

--- a/examples/triton-docker-combined/terraform.tfvars.example
+++ b/examples/triton-docker-combined/terraform.tfvars.example
@@ -1,7 +1,7 @@
-account = "bobby.brown"
+triton_account = "bobby.brown"
 triton_url = "https://us-sw-1.api.joyentcloud.com"
-key_path = "~/.ssh/joyent_id_rsa"
-key_id = "<KEY_FINGERPRINT>"
+triton_key_path = "~/.ssh/joyent_id_rsa"
+triton_key_id = "<KEY_FINGERPRINT>"
 
-cert_path = "/Users/<USER>/.sdc/docker/<SDC_ACCOUNT>"
+docker_cert_path = "/Users/<USER>/.sdc/docker/<SDC_ACCOUNT>"
 docker_host = "tcp://us-sw-1.docker.joyent.com:2376"

--- a/examples/triton-docker-combined/triton.tf
+++ b/examples/triton-docker-combined/triton.tf
@@ -1,15 +1,15 @@
 # See http://www.joyent.com/blog/introducing-hashicorp-terraform-for-joyent-triton
 
 provider "triton" {
-  account = "${var.account}"
-  key = "${var.key_path}"
-  key_id = "${var.key_id}"
+  account = "${var.triton_account}"
+  key = "${var.triton_key_path}"
+  key_id = "${var.triton_key_id}"
   url = "${var.triton_url}"
 }
 
 provider "docker" {
   host = "${var.docker_host}"
-  cert_path = "${var.cert_path}"
+  cert_path = "${var.docker_cert_path}"
 }
 
 resource "docker_image" "nginx" {

--- a/examples/triton-docker-combined/triton.tf
+++ b/examples/triton-docker-combined/triton.tf
@@ -1,0 +1,48 @@
+# See http://www.joyent.com/blog/introducing-hashicorp-terraform-for-joyent-triton
+
+provider "triton" {
+  account = "${var.account}"
+  key = "${var.key_path}"
+  key_id = "${var.key_id}"
+  url = "${var.triton_url}"
+}
+
+provider "docker" {
+  host = "${var.docker_host}"
+  cert_path = "${var.cert_path}"
+}
+
+resource "docker_image" "nginx" {
+  name = "nginx:latest"
+  keep_updated = true
+}
+
+resource "docker_container" "nginx" {
+  count = 1
+  name = "nginx-terraform-${format("%02d", count.index+1)}"
+  image = "${docker_image.nginx.latest}"
+  must_run = true
+
+  env = ["env=test", "role=test"]
+
+  ports {
+    internal = 80
+    external = 80
+  }
+}
+
+resource "triton_machine" "testmachine" {
+  name = "test-machine"
+  package = "t4-standard-512M"
+  image = "ffe82a0a-83d2-11e5-b5ac-f3e14f42f12d"
+
+  count = 1
+}
+
+resource "triton_machine" "windowsmachine" {
+  name = "win-test-terraform"
+  package = "333814c2-b4a7-481f-9f86-73bb4122c7a3"
+  image = "66810176-4011-11e4-968f-938d7c9edfa2"
+
+  count = 1
+}

--- a/examples/triton-docker-combined/triton.tf
+++ b/examples/triton-docker-combined/triton.tf
@@ -54,7 +54,7 @@ resource "triton_machine" "testmachine" {
 
 resource "triton_machine" "windowsmachine" {
   name = "win-test-terraform"
-  package = "333814c2-b4a7-481f-9f86-73bb4122c7a3"
+  package = "g3-standard-4-kvm"
   image = "66810176-4011-11e4-968f-938d7c9edfa2"
 
   count = 1

--- a/examples/triton-docker-combined/triton.tf
+++ b/examples/triton-docker-combined/triton.tf
@@ -24,6 +24,19 @@ resource "docker_container" "nginx" {
   must_run = true
 
   env = ["env=test", "role=test"]
+  restart = "always"
+  memory = 128
+
+  labels {
+    env = "test"
+    role = "docker"
+  }
+
+  log_driver = "json-file"
+  log_opts = {
+    max-size = "1m"
+    max-file = 2
+  }
 
   ports {
     internal = 80

--- a/examples/triton-docker-combined/variables.tf
+++ b/examples/triton-docker-combined/variables.tf
@@ -1,0 +1,8 @@
+variable "account" {}
+variable "triton_url" {}
+variable "key_path" {}
+variable "key_id" {}
+variable "cert_path" {}
+variable "docker_host" {
+ default = "tcp://us-sw-1.docker.joyent.com:2376"
+}

--- a/examples/triton-docker-combined/variables.tf
+++ b/examples/triton-docker-combined/variables.tf
@@ -3,7 +3,7 @@ variable "triton_url" {
   default = "https://us-sw-1.api.joyentcloud.com"
 }
 variable "triton_key_path" {
-  default = "path to your ssh key for triton"
+  default = "path to your ssh key for Triton"
 }
 variable "triton_key_id" {
   default = "Run 'ssh-keygen -l -E md5 -f <TRITON_KEY_PATH> | cut -d' ' -f2 | cut -d: -f2-'"

--- a/examples/triton-docker-combined/variables.tf
+++ b/examples/triton-docker-combined/variables.tf
@@ -1,8 +1,14 @@
-variable "account" {}
-variable "triton_url" {}
-variable "key_path" {}
-variable "key_id" {}
-variable "cert_path" {}
+variable "triton_account" {}
+variable "triton_url" {
+  default = "https://us-sw-1.api.joyentcloud.com"
+}
+variable "triton_key_path" {
+  default = "path to your ssh key for triton"
+}
+variable "triton_key_id" {}
+variable "docker_cert_path" {
+  default = "/Users/<USER>/.sdc/docker/<TRITON_ACCOUNT>"
+}
 variable "docker_host" {
- default = "tcp://us-sw-1.docker.joyent.com:2376"
+  default = "tcp://us-sw-1.docker.joyent.com:2376"
 }

--- a/examples/triton-docker-combined/variables.tf
+++ b/examples/triton-docker-combined/variables.tf
@@ -5,7 +5,9 @@ variable "triton_url" {
 variable "triton_key_path" {
   default = "path to your ssh key for triton"
 }
-variable "triton_key_id" {}
+variable "triton_key_id" {
+  default = "Run 'ssh-keygen -l -E md5 -f <TRITON_KEY_PATH> | cut -d' ' -f2 | cut -d: -f2-'"
+}
 variable "docker_cert_path" {
   default = "/Users/<USER>/.sdc/docker/<TRITON_ACCOUNT>"
 }


### PR DESCRIPTION
This adds the example .tf file from our introduction to terraform blog post. The example directory is styled after the official terraform examples.