### PR TITLE
Fabric resources

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -40,9 +40,11 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"triton_key":           resourceKey(),
-			"triton_machine":       resourceMachine(),
-			"triton_firewall_rule": resourceFirewallRule(),
+			"triton_key":            resourceKey(),
+			"triton_machine":        resourceMachine(),
+			"triton_firewall_rule":  resourceFirewallRule(),
+			"triton_fabric_vlan":    resourceFabricVLAN(),
+			"triton_fabric_network": resourceFabricNetwork(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/resource_fabric_network.go
+++ b/resource_fabric_network.go
@@ -1,0 +1,214 @@
+package main
+
+import (
+	"errors"
+	"regexp"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/joyent/gosdc/cloudapi"
+)
+
+func resourceFabricNetwork() *schema.Resource {
+	return &schema.Resource{
+		Create: wrapCallback(resourceFabricNetworkCreate),
+		Exists: wrapExistsCallback(resourceFabricNetworkExists),
+		Read:   wrapCallback(resourceFabricNetworkRead),
+		Delete: wrapCallback(resourceFabricNetworkDelete),
+
+		Schema: map[string]*schema.Schema{
+			"vlan_id": {
+				Description: "id of VLAN to create network on",
+				Type:        schema.TypeInt,
+				Required:    true,
+				ForceNew:    true,
+			},
+
+			"name": {
+				Description: "name of network",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+
+			"public": {
+				Description: "flag if network is not a RFC1918 private network",
+				Type:        schema.TypeBool,
+				Computed:    true,
+			},
+
+			"fabric": {
+				Description: "flag if network is created on a fabric",
+				Type:        schema.TypeBool,
+				Computed:    true,
+			},
+
+			"description": {
+				Description: "description of network",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				ForceNew:    true,
+			},
+
+			"subnet": {
+				Description: "CIDR formatted string describing network",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+
+			"start_ip": {
+				Description: "first assignable IP on network",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+
+			"end_ip": {
+				Description: "last assignable IP on network",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+			},
+
+			"gateway": {
+				Description: "address of gateway on network, nat zone is created here",
+				Type:        schema.TypeString,
+				Optional:    true,
+				ForceNew:    true,
+				Computed:    true,
+			},
+
+			"resolvers": {
+				Description: "list of resolvers to use on network",
+				Type:        schema.TypeList,
+				// This says it is optional, but the cloud api requires it be present.
+				// I'm unsure if this is passing an empty array or object because
+				// the error from the api says object value found but array needed.
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				ForceNew: true,
+			},
+
+			"routes": {
+				Description: "map of static routes for hosts on network",
+				Type:        schema.TypeMap,
+				Optional:    true,
+				ForceNew:    true,
+			},
+
+			"internet_nat": {
+				Description: "whether to create a NAT to the internet at the gateway IP",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				ForceNew:    true,
+			},
+		},
+	}
+}
+
+func resourceFabricNetworkCreate(d ResourceData, config *Config) error {
+	cloud, err := config.Cloud()
+	if err != nil {
+		return err
+	}
+
+	valid, err := regexp.MatchString("^[a-zA-Z][a-zA-Z0-9_\\\\./-]{1,255}$", d.Get("name").(string))
+	if !valid || err != nil {
+		return errors.New("\"name\" must be at most 255 characters and contain only letters, numbers, _, \\, /, -, and .")
+	}
+
+	var resolvers []string
+	for _, resolver := range d.Get("resolvers").([]interface{}) {
+		resolvers = append(resolvers, resolver.(string))
+	}
+
+	routes := map[string]string{}
+	for k, v := range d.Get("routes").(map[string]interface{}) {
+		routes[k] = v.(string)
+	}
+
+	network, err := cloud.CreateFabricNetwork(
+		int16(d.Get("vlan_id").(int)),
+		cloudapi.CreateFabricNetworkOpts{
+			Name:             d.Get("name").(string),
+			Description:      d.Get("description").(string),
+			Subnet:           d.Get("subnet").(string),
+			ProvisionStartIp: d.Get("start_ip").(string),
+			ProvisionEndIp:   d.Get("end_ip").(string),
+			Gateway:          d.Get("gateway").(string),
+			Resolvers:        resolvers,
+			Routes:           routes,
+			InternetNAT:      d.Get("internet_nat").(bool),
+		})
+	if err != nil {
+		return err
+	}
+
+	d.SetId(network.Id)
+
+	err = resourceFabricNetworkRead(d, config)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceFabricNetworkExists(d ResourceData, config *Config) (bool, error) {
+	cloud, err := config.Cloud()
+	if err != nil {
+		return false, err
+	}
+
+	network, err := cloud.GetFabricNetwork(int16(d.Get("vlan_id").(int)), d.Id())
+
+	return network != nil && err == nil, err
+}
+
+func resourceFabricNetworkRead(d ResourceData, config *Config) error {
+	cloud, err := config.Cloud()
+	if err != nil {
+		return err
+	}
+
+	network, err := cloud.GetFabricNetwork(int16(d.Get("vlan_id").(int)), d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.SetId(network.Id)
+	d.Set("vlan_id", network.VLANId)
+	d.Set("name", network.Name)
+	d.Set("public", network.Public)
+	d.Set("fabric", network.Fabric)
+	d.Set("description", network.Description)
+	d.Set("subnet", network.Subnet)
+	d.Set("start_ip", network.ProvisionStartIp)
+	d.Set("end_ip", network.ProvisionEndIp)
+	d.Set("gateway", network.Gateway)
+	d.Set("resolvers", network.Resolvers)
+	d.Set("routes", network.Routes)
+	d.Set("internet_nat", network.InternetNAT)
+
+	return nil
+}
+
+func resourceFabricNetworkDelete(d ResourceData, config *Config) error {
+	cloud, err := config.Cloud()
+	if err != nil {
+		return err
+	}
+
+	err = cloud.DeleteFabricNetwork(int16(d.Get("vlan_id").(int)), d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+
+	return nil
+}

--- a/resource_fabric_network.go
+++ b/resource_fabric_network.go
@@ -50,10 +50,11 @@ func resourceFabricNetwork() *schema.Resource {
 			},
 
 			"subnet": {
-				Description: "CIDR formatted string describing network",
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
+				Description:  "CIDR formatted string describing network",
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: resourceFabricValidateCIDR,
 			},
 
 			"start_ip": {

--- a/resource_fabric_network.go
+++ b/resource_fabric_network.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"errors"
-	"regexp"
-
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/joyent/gosdc/cloudapi"
 )
@@ -17,17 +14,19 @@ func resourceFabricNetwork() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"vlan_id": {
-				Description: "id of VLAN to create network on",
-				Type:        schema.TypeInt,
-				Required:    true,
-				ForceNew:    true,
+				Description:  "id of VLAN to create network on",
+				Type:         schema.TypeInt,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: resourceFabricValidateVLAN,
 			},
 
 			"name": {
-				Description: "name of network",
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
+				Description:  "name of network",
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: resourceFabricValidateName,
 			},
 
 			"public": {
@@ -58,25 +57,28 @@ func resourceFabricNetwork() *schema.Resource {
 			},
 
 			"start_ip": {
-				Description: "first assignable IP on network",
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
+				Description:  "first assignable IP on network",
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: resourceFabricValidateIPv4,
 			},
 
 			"end_ip": {
-				Description: "last assignable IP on network",
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
+				Description:  "last assignable IP on network",
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: resourceFabricValidateIPv4,
 			},
 
 			"gateway": {
-				Description: "address of gateway on network, nat zone is created here",
-				Type:        schema.TypeString,
-				Optional:    true,
-				ForceNew:    true,
-				Computed:    true,
+				Description:  "address of gateway on network, nat zone is created here",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				Computed:     true,
+				ValidateFunc: resourceFabricValidateIPv4,
 			},
 
 			"resolvers": {
@@ -87,7 +89,8 @@ func resourceFabricNetwork() *schema.Resource {
 				// the error from the api says object value found but array needed.
 				Required: true,
 				Elem: &schema.Schema{
-					Type: schema.TypeString,
+					Type:         schema.TypeString,
+					ValidateFunc: resourceFabricValidateIPv4,
 				},
 				ForceNew: true,
 			},
@@ -114,11 +117,6 @@ func resourceFabricNetworkCreate(d ResourceData, config *Config) error {
 	cloud, err := config.Cloud()
 	if err != nil {
 		return err
-	}
-
-	valid, err := regexp.MatchString("^[a-zA-Z][a-zA-Z0-9_\\\\./-]{1,255}$", d.Get("name").(string))
-	if !valid || err != nil {
-		return errors.New("\"name\" must be at most 255 characters and contain only letters, numbers, _, \\, /, -, and .")
 	}
 
 	var resolvers []string

--- a/resource_fabric_validations.go
+++ b/resource_fabric_validations.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"regexp"
+)
+
+func resourceFabricValidateVLAN(value interface{}, name string) (warnings []string, errors []error) {
+	if value.(int) < 0 || value.(int) > 4095 {
+		errors = append(errors, fmt.Errorf(`"%s" must be between 0 and 4095`, name))
+	}
+	return
+}
+
+func resourceFabricValidateName(value interface{}, name string) (warnings []string, errors []error) {
+	valid, err := regexp.MatchString(`^[a-zA-Z][a-zA-Z0-9_\\./-]{1,255}$`, value.(string))
+	if !valid || err != nil {
+		errors = append(errors, fmt.Errorf(`"%s" must be at most 255 characters and contain only letters, numbers, _, \, /, -, and .`, name))
+	}
+	return
+}
+
+func resourceFabricValidateIPv4(value interface{}, name string) (warnings []string, errors []error) {
+	valid, err := regexp.MatchString(`^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$`, value.(string))
+	if !valid || err != nil {
+		errors = append(errors, fmt.Errorf(`"%s" must be an IPv4 address`, name))
+	}
+	return
+}

--- a/resource_fabric_vlan.go
+++ b/resource_fabric_vlan.go
@@ -17,16 +17,18 @@ func resourceFabricVLAN() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"vlan_id": {
-				Description: "VLAN Id between 0-4095",
-				Type:        schema.TypeInt,
-				Required:    true,
-				ForceNew:    true,
+				Description:  "VLAN Id between 0-4095",
+				Type:         schema.TypeInt,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: resourceFabricValidateVLAN,
 			},
 
 			"name": {
-				Description: "Unique name of VLAN",
-				Type:        schema.TypeString,
-				Required:    true,
+				Description:  "Unique name of VLAN",
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: resourceFabricValidateName,
 			},
 
 			"description": {

--- a/resource_fabric_vlan.go
+++ b/resource_fabric_vlan.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/joyent/gosdc/cloudapi"
+)
+
+func resourceFabricVLAN() *schema.Resource {
+	return &schema.Resource{
+		Create: wrapCallback(resourceFabricVLANCreate),
+		Exists: wrapExistsCallback(resourceFabricVLANExists),
+		Read:   wrapCallback(resourceFabricVLANRead),
+		Update: wrapCallback(resourceFabricVLANUpdate),
+		Delete: wrapCallback(resourceFabricVLANDelete),
+
+		Schema: map[string]*schema.Schema{
+			"vlan_id": {
+				Description: "VLAN Id between 0-4095",
+				Type:        schema.TypeInt,
+				Required:    true,
+				ForceNew:    true,
+			},
+
+			"name": {
+				Description: "Unique name of VLAN",
+				Type:        schema.TypeString,
+				Required:    true,
+			},
+
+			"description": {
+				Description: "Description of VLAN",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+			},
+		},
+	}
+}
+
+func resourceFabricVLANCreate(d ResourceData, config *Config) error {
+	cloud, err := config.Cloud()
+	if err != nil {
+		return err
+	}
+
+	_, err = cloud.CreateFabricVLAN(cloudapi.FabricVLAN{
+		Id:          int16(d.Get("vlan_id").(int)),
+		Name:        d.Get("name").(string),
+		Description: d.Get("description").(string),
+	})
+	if err != nil {
+		return err
+	}
+
+	d.SetId(strconv.Itoa(d.Get("vlan_id").(int)))
+
+	err = resourceFabricVLANRead(d, config)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourceFabricVLANExists(d ResourceData, config *Config) (bool, error) {
+	cloud, err := config.Cloud()
+	if err != nil {
+		return false, err
+	}
+
+	vlanId, err := strconv.ParseInt(d.Id(), 10, 16)
+	if err != nil {
+		return false, err
+	}
+
+	vlan, err := cloud.GetFabricVLAN(int16(vlanId))
+
+	return vlan != nil && err == nil, err
+}
+
+func resourceFabricVLANRead(d ResourceData, config *Config) error {
+	cloud, err := config.Cloud()
+	if err != nil {
+		return err
+	}
+
+	vlanId, err := strconv.ParseInt(d.Id(), 10, 16)
+	if err != nil {
+		return err
+	}
+
+	vlan, err := cloud.GetFabricVLAN(int16(vlanId))
+	if err != nil {
+		return err
+	}
+
+	d.Set("vlan_id", vlan.Id)
+	d.Set("name", vlan.Name)
+	d.Set("description", vlan.Description)
+
+	return nil
+}
+
+func resourceFabricVLANUpdate(d ResourceData, config *Config) error {
+	cloud, err := config.Cloud()
+	if err != nil {
+		return err
+	}
+
+	vlanId, err := strconv.ParseInt(d.Id(), 10, 16)
+	if err != nil {
+		return err
+	}
+
+	_, err = cloud.UpdateFabricVLAN(
+		cloudapi.FabricVLAN{
+			Id:          int16(vlanId),
+			Name:        d.Get("name").(string),
+			Description: d.Get("description").(string),
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	return resourceFabricVLANRead(d, config)
+}
+
+func resourceFabricVLANDelete(d ResourceData, config *Config) error {
+	cloud, err := config.Cloud()
+	if err != nil {
+		return err
+	}
+
+	vlanId, err := strconv.ParseInt(d.Id(), 10, 16)
+	if err != nil {
+		return err
+	}
+
+	err = cloud.DeleteFabricVLAN(int16(vlanId))
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+
+	return nil
+}


### PR DESCRIPTION
This adds resources `triton_fabric_vlan` and `triton_fabric_network` and requires joyent/gosdc#17. I would like to get tests going on this like the API pull request.

I have an open problem with this implementation that I don't know where the blame lies. Resolvers are stated as optional in the CloudAPI documentation, but I can not omit them from the request. If I pass along an empty array from the terraform config, the api returns with

~~~
caused by: Missing parameters https://cloudapi.hsv-1.csfoundry.com/cehoffman/fabrics/default/vlans/8/networks
caused by: request "https://cloudapi.hsv-1.csfoundry.com/cehoffman/fabrics/default/vlans/8/networks" returned unexpected status 409 with body "{\"code\":\"InvalidArgument\",\"message\":\"property \\\"resolvers\\\": object value found, but a array is required\"}"
~~~

I think there might be some magic in the Go struct to JSON conversion that I'm missing because based on the error it sounds like an `{}` is being used even though resolvers is defined as `[]string`.

I expect this closes #8.